### PR TITLE
feat: add coolify deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: CI/CD
+
+on:
+  push:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "${{ github.repository }}"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Run database migrations
+        run: npm run migration:run
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: Trigger Coolify deployment
+        run: |
+          curl --request GET "${{ secrets.COOLIFY_WEBHOOK }}" \
+            --header "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ TZ=Asia/Baku
 
 - Selectors in the scraper are heuristics and may need minor adjustments.
 - Outbox pattern ensures reliability; failed sends retry up to 5 times.
+
+## Deployment
+
+This service is deployed to a single production environment via [Coolify](https://coolify.io).
+Each push to `main` triggers a GitHub Actions workflow that:
+
+1. Builds the application and runs database migrations.
+2. Pushes the Docker image to GitHub Container Registry.
+3. Calls the Coolify deployment webhook to update the live instance.
+
+Configure the following secrets in your repository settings for the
+workflow to succeed:
+
+- `DATABASE_URL` – PostgreSQL connection string used for migrations.
+- `COOLIFY_WEBHOOK` – deployment URL from your Coolify instance.
+- `COOLIFY_TOKEN` – API token for authenticating with Coolify.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for building, pushing and deploying through Coolify
- document required secrets for production deployment
- remove explicit production URL from README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f239fb6c83329a5620646a9c947e